### PR TITLE
Added cross-platform PropertyListEncoder/Decoder support on Swift 5.1+

### DIFF
--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -17,7 +17,7 @@ public protocol AnyEncoder {
 
 extension JSONEncoder: AnyEncoder {}
 
-#if canImport(ObjectiveC)
+#if canImport(ObjectiveC) || swift(>=5.1)
 extension PropertyListEncoder: AnyEncoder {}
 #endif
 
@@ -72,7 +72,7 @@ public protocol AnyDecoder {
 
 extension JSONDecoder: AnyDecoder {}
 
-#if canImport(ObjectiveC)
+#if canImport(ObjectiveC) || swift(>=5.1)
 extension PropertyListDecoder: AnyDecoder {}
 #endif
 


### PR DESCRIPTION
-> swift-corelibs-foundation [#1849](https://github.com/apple/swift-corelibs-foundation/pull/1849)