### PR TITLE
Added EncodeTransformable & DecodeTransformable

### DIFF
--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -47,17 +47,27 @@ public extension Encoder {
         try container.encode(value, forKey: key)
     }
 
-    /// Encode a date for a given key (specified as a string), using a specific formatter.
-    /// To encode a date without using a specific formatter, simply encode it like any other value.
-    func encode(_ date: Date, for key: String, using formatter: DateFormatter) throws {
-        try encode(date, for: AnyCodingKey(key), using: formatter)
+    /// Encode a value for a given key (specified as a string), using a concrete EncodeTransformable.
+    ///
+    /// - Parameters:
+    ///   - value: The value
+    ///   - key: The key as a string
+    ///   - transformable: The concrete EncodeTransformable
+    /// - Throws: If encoding fails
+    func encode<T: EncodeTransformable>(_ value: T.EncodeSourceType, for key: String, using transformable: T) throws {
+        try encode(value, for: AnyCodingKey(key), using: transformable)
     }
-
-    /// Encode a date for a given key (specified using a `CodingKey`), using a specific formatter.
-    /// To encode a date without using a specific formatter, simply encode it like any other value.
-    func encode<K: CodingKey>(_ date: Date, for key: K, using formatter: DateFormatter) throws {
-        let string = formatter.string(from: date)
-        try encode(string, for: key)
+    
+    /// Encode a value for a given key (specified using a `CodingKey`), using a concrete EncodeTransformable
+    ///
+    /// - Parameters:
+    ///   - value: The value
+    ///   - key: The CodingKey
+    ///   - transformable: The concrete EncodeTransformable
+    /// - Throws: If encoding fails
+    func encode<K: CodingKey, T: EncodeTransformable>(_ value: T.EncodeSourceType, for key: K, using transformable: T) throws {
+        let encodableValue = transformable.transformToEncodable(value: value)
+        try encode(encodableValue, for: key)
     }
 }
 

--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -113,29 +113,28 @@ public extension Decoder {
         return try container.decode(type, forKey: key)
     }
 
-    /// Decode a date from a string for a given key (specified as a string), using a
-    /// specific formatter. To decode a date using the decoder's default settings,
-    /// simply decode it like any other value instead of using this method.
-    func decode(_ key: String, using formatter: DateFormatter) throws -> Date {
-        return try decode(AnyCodingKey(key), using: formatter)
+    /// Decode a value for a given key specified as a string), using a concrete DecodeTransformable
+    ///
+    /// - Parameters:
+    ///   - key: The key as a string
+    ///   - transformable: The concrete DecodeTransformable
+    /// - Returns: The DecodeTransformable TargetType value
+    /// - Throws: If decoding fails
+    func decode<T: DecodeTransformable>(_ key: String, using transformable: T) throws -> T.DecodeTargetType {
+        return try decode(AnyCodingKey(key), using: transformable)
     }
-
-    /// Decode a date from a string for a given key (specified as a `CodingKey`), using
-    /// a specific formatter. To decode a date using the decoder's default settings,
-    /// simply decode it like any other value instead of using this method.
-    func decode<K: CodingKey>(_ key: K, using formatter: DateFormatter) throws -> Date {
+    
+    /// Decode a value for a given key specified as a `CodingKey`), using a concrete DecodeTransformable
+    ///
+    /// - Parameters:
+    ///   - key: The CodingKey
+    ///   - transformable: The concrete DecodeTransformable
+    /// - Returns: The DecodeTransformable TargetType value
+    /// - Throws: If decoding fails
+    func decode<K: CodingKey, T: DecodeTransformable>(_ key: K, using transformable: T) throws -> T.DecodeTargetType {
         let container = try self.container(keyedBy: K.self)
-        let rawString = try container.decode(String.self, forKey: key)
-
-        guard let date = formatter.date(from: rawString) else {
-            throw DecodingError.dataCorruptedError(
-                forKey: key,
-                in: container,
-                debugDescription: "Unable to format date string"
-            )
-        }
-
-        return date
+        let decodedValue = try container.decode(T.DecodeSourceType.self, forKey: key)
+        return transformable.transformFromDecodable(value: decodedValue)
     }
 }
 

--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -66,7 +66,7 @@ public extension Encoder {
     ///   - transformable: The concrete EncodeTransformable
     /// - Throws: If encoding fails
     func encode<K: CodingKey, T: EncodeTransformable>(_ value: T.EncodeSourceType, for key: K, using transformable: T) throws {
-        let encodableValue = transformable.transformToEncodable(value: value)
+        let encodableValue = try transformable.transformToEncodable(value: value)
         try encode(encodableValue, for: key)
     }
 }
@@ -134,7 +134,7 @@ public extension Decoder {
     func decode<K: CodingKey, T: DecodeTransformable>(_ key: K, using transformable: T) throws -> T.DecodeTargetType {
         let container = try self.container(keyedBy: K.self)
         let decodedValue = try container.decode(T.DecodeSourceType.self, forKey: key)
-        return transformable.transformFromDecodable(value: decodedValue)
+        return try transformable.transformFromDecodable(value: decodedValue)
     }
 }
 
@@ -177,7 +177,8 @@ public protocol EncodeTransformable {
     ///
     /// - Parameter value: The EncodeSourceType value
     /// - Returns: The transformed Encodable TargetType
-    func transformToEncodable(value: EncodeSourceType) -> EncodeTargetType
+    /// - Throws: If transforming fails
+    func transformToEncodable(value: EncodeSourceType) throws -> EncodeTargetType
     
 }
 
@@ -197,7 +198,8 @@ public protocol DecodeTransformable {
     ///
     /// - Parameter decodedValue: The decodable value
     /// - Returns: The transformed Decode TargetType
-    func transformFromDecodable(value: DecodeSourceType) -> DecodeTargetType
+    /// - Throws: If transforming fails
+    func transformFromDecodable(value: DecodeSourceType) throws -> DecodeTargetType
     
 }
 
@@ -205,11 +207,11 @@ public protocol DecodeTransformable {
 
 extension DateFormatter: Transformable {
     
-    public func transformToEncodable(value: Date) -> String {
+    public func transformToEncodable(value: Date) throws -> String {
         return self.string(from: value)
     }
     
-    public func transformFromDecodable(value: String) -> Date? {
+    public func transformFromDecodable(value: String) throws -> Date? {
         return self.date(from: value)
     }
     

--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -146,3 +146,48 @@ private struct AnyCodingKey: CodingKey {
         self.stringValue = String(intValue)
     }
 }
+
+// MARK: - Transformable
+
+/// The Transformable typealias which is the protocol composition of `EncodeTransformable` and `DecodeTransformable`
+public typealias Transformable = EncodeTransformable & DecodeTransformable
+
+// MARK: - EncodeTransformable
+
+/// The EncodeTransformable acting as a value-converter to
+/// transform a given SourceType to an Encodable TargetType
+public protocol EncodeTransformable {
+    
+    /// The EncodeSourceType
+    associatedtype EncodeSourceType
+    
+    /// The EncodeTargetType which must be conform to Encodable
+    associatedtype EncodeTargetType: Encodable
+    
+    /// Transform the SourceType value to the Encodable TargetType
+    ///
+    /// - Parameter value: The EncodeSourceType value
+    /// - Returns: The transformed Encodable TargetType
+    func transformToEncodable(value: EncodeSourceType) -> EncodeTargetType
+    
+}
+
+// MARK: - DecodeTransformable
+
+/// The DecodeTranformable acting as a value-converter to
+/// transform a given DecodeSourceType to an DecodeTargetType
+public protocol DecodeTransformable {
+    
+    /// The DecodeSourceType which mus be conform to Decodable
+    associatedtype DecodeSourceType: Decodable
+    
+    /// The DecodeTargetType
+    associatedtype DecodeTargetType
+    
+    /// Transform the decodable SourceType value to the TargetType
+    ///
+    /// - Parameter decodedValue: The decodable value
+    /// - Returns: The transformed Decode TargetType
+    func transformFromDecodable(value: DecodeSourceType) -> DecodeTargetType
+    
+}

--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -191,3 +191,17 @@ public protocol DecodeTransformable {
     func transformFromDecodable(value: DecodeSourceType) -> DecodeTargetType
     
 }
+
+// MARK: - DateFormatter+Transformable
+
+extension DateFormatter: Transformable {
+    
+    public func transformToEncodable(value: Date) -> String {
+        return self.string(from: value)
+    }
+    
+    public func transformFromDecodable(value: String) -> Date? {
+        return self.date(from: value)
+    }
+    
+}

--- a/Tests/CodextendedTests/CodextendedTests.swift
+++ b/Tests/CodextendedTests/CodextendedTests.swift
@@ -109,7 +109,7 @@ final class CodextendedTests: XCTestCase {
 
             init(from decoder: Decoder) throws {
                 let formatter = Value.makeDateFormatter()
-                date = try decoder.decode("key", using: formatter)
+                date = try decoder.decode("key", using: formatter) ?? .init()
             }
 
             func encode(to encoder: Encoder) throws {
@@ -127,27 +127,6 @@ final class CodextendedTests: XCTestCase {
                        formatter.string(from: valueB.date))
     }
 
-    func testDecodingErrorThrownForInvalidDateString() {
-        struct Value: Decodable {
-            let date: Date
-
-            init(date: Date) {
-                self.date = date
-            }
-
-            init(from decoder: Decoder) throws {
-                date = try decoder.decode("key", using: DateFormatter())
-            }
-        }
-
-        let data = Data(#"{"key": "notADate"}"#.utf8)
-
-        XCTAssertThrowsError(try data.decoded() as Value) { error in
-            XCTAssertTrue(error is DecodingError,
-                          "Expected DecodingError but got \(type(of: error))")
-        }
-    }
-
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux()
     }
@@ -159,7 +138,6 @@ extension CodextendedTests: LinuxTestable {
         ("testSingleValue", testSingleValue),
         ("testUsingStringAsKey", testUsingStringAsKey),
         ("testUsingCodingKey", testUsingCodingKey),
-        ("testDateWithCustomFormatter", testDateWithCustomFormatter),
-        ("testDecodingErrorThrownForInvalidDateString", testDecodingErrorThrownForInvalidDateString)
+        ("testDateWithCustomFormatter", testDateWithCustomFormatter)
     ]
 }


### PR DESCRIPTION
Hey John 🙌,

First of all great job with `Codextended` 👍

This PR refactored the `encode` and `decode` API when using an `DateFormatter` to an protocol-oriented solution, allowing to pass any kind of `EncodeTransformable` or `DecodeTransformable` implementation in order to transform / convert / manipulate the value.

```swift
public typealias Transformable = EncodeTransformable & DecodeTransformable

public protocol EncodeTransformable {
    associatedtype EncodeSourceType

    associatedtype EncodeTargetType: Encodable

    func transformToEncodable(value: EncodeSourceType) throws -> EncodeTargetType
}

public protocol DecodeTransformable {
    associatedtype DecodeSourceType: Decodable

    associatedtype DecodeTargetType

    func transformFromDecodable(value: DecodeSourceType) throws -> DecodeTargetType
}
```
The `DateFormatter` has already been adopted to the `Transformable` protocol which allows to use the `encode` and `decode` API when passing an `DateFormatter` as there was no change.

```swift
extension DateFormatter: Transformable {
    public func transformToEncodable(value: Date) throws -> String {
        return self.string(from: value)
    }
    
    public func transformFromDecodable(value: String) throws -> Date? {
        return self.date(from: value)
    }   
}
```

Even nicer developers can now pass any kind of `EncodeTransformable` or `DecodeTransformable` to the `encode` and `decode` API. For example a simple `IntToStringTransformable`.

```swift
struct Article: Codable {
    var id: String
    var body: String
    var date: Date?

    init(from decoder: Decoder) throws {
        id = try container.decode("id", using: IntToStringTransformable())
        body = try container.decode("body")
        date = try container.decode("date", using: DateFormatter())
    }
}

struct IntToStringTransformable: Transformable {
    func transformFromDecodable(value: Int) throws -> String {
        return .init(value)
    }
    
    func transformToEncodable(value: String) throws -> Int? {
        return Int(value)
    }
}
```

**Additional thoughts:**
The current `Transformable` implementation for the `DateFormatter` will return an optional `Date`, based on the `date(from:)` API of the `DateFormatter` itself, when invoking the `transformFromDecodable` API.

Before a `DecodingError` has been thrown when the `Date` is `nil`. I was not a 100% sure if throwing an `Error` or returning an optional `Date` is better.

So I chose the second option so that the developer can decide if either to provide a default value or manually thrown an `DecodingError`.

I'm excited about your feedback ✌️