### PR TITLE
Implemented decodeArraySafely

### DIFF
--- a/Tests/CodextendedTests/CodextendedTests.swift
+++ b/Tests/CodextendedTests/CodextendedTests.swift
@@ -176,6 +176,39 @@ final class CodextendedTests: XCTestCase {
                           "Expected DecodingError but got \(type(of: error))")
         }
     }
+    
+    func testDecodeArraySafely() throws {
+        struct NilFound: Error {}
+        struct Value: Decodable, Equatable {
+            let numbers: [Int]
+
+            init(numbers: [Int]) {
+                self.numbers = numbers
+            }
+
+            init(from decoder: Decoder) throws {
+                self.numbers = try decoder.decodeArraySafely("numbers")
+            }
+        }
+ 
+        do {
+            let data = #"{ "numbers": [ 1, 2, 3, 4 ] }"#.data(using: .utf8)!
+            let value = try data.decoded() as Value
+            XCTAssertEqual(
+                value,
+                Value(numbers: [1, 2, 3, 4])
+            )
+        }
+        
+        do {
+            let data = #"{ "numbers": [ 1, 2, "3", 4 ] }"#.data(using: .utf8)!
+            let value = try data.decoded() as Value
+            XCTAssertEqual(
+                value,
+                Value(numbers: [1, 2, 4])
+            )
+        }
+    }
 
     func testAllTestsRunOnLinux() {
         verifyAllTestsRunOnLinux(excluding: ["testDateWithISO8601Formatter"])
@@ -189,6 +222,7 @@ extension CodextendedTests: LinuxTestable {
         ("testUsingStringAsKey", testUsingStringAsKey),
         ("testUsingCodingKey", testUsingCodingKey),
         ("testDateWithCustomFormatter", testDateWithCustomFormatter),
-        ("testDecodingErrorThrownForInvalidDateString", testDecodingErrorThrownForInvalidDateString)
+        ("testDecodingErrorThrownForInvalidDateString", testDecodingErrorThrownForInvalidDateString),
+        ("testDecodeArraySafely", testDecodeArraySafely)
     ]
 }


### PR DESCRIPTION
Hi John!
I really enjoyed the philosophy of this library and I'm happy to have these improvements to Codable in the open. 

One of the frustrations that i always have to workaround in Codable is having a way to safely decode an array of objects safely ignoring the ones that fail to decode, instead of blowing up the entire array as the default system does.  

So trying to decode `{ "numbers": [ 1, 2, "3", 4 ] }` to `let numbers: [Int]` won't fail, instead you will receive an array of `[1, 2, 4]`.  

I thought that this may be a common enough use case to include it in the library so I spend some time porting it and trying to match the style of this code. I also wrote test to make sure the normal case (all elements are correct) works and that the case of elements failing also works. (There are 2 assertions in the same test, if you prefer to split them feel free to tell me). 

Suffices to say that if you don't consider this to be inline with the library's intend feel free to close it 😉 