### PR TITLE
Support error propagation for optional properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,20 @@ struct Article: Codable {
     enum CodingKeys: CodingKey {
         case title
         case body
+        case footnotes
         case tags
     }
 
     var title: String
     var body: String
+    var footnotes: String?
     var tags: [String]
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         title = try container.decode(String.self, forKey: .title)
         body = try container.decode(String.self, forKey: .body)
+        footnotes = try container.decodeIfPresent(String.self, forKey: .footnotes)
         tags = (try? container.decode([String].self, forKey: .tags)) ?? []
     }
 }
@@ -91,11 +94,15 @@ struct Article: Codable {
 struct Article: Codable {
     var title: String
     var body: String
+    var footnotes: String?
     var tags: [String]
 
     init(from decoder: Decoder) throws {
         title = try decoder.decode("title")
         body = try decoder.decode("body")
+        footnotes = try decoder.decodeIfPresent("footnotes")
+        // Or if you prefer to ignore type errors for optional properties, you can use:
+        // footnotes = try? decoder.decode("footnotes")
         tags = (try? decoder.decode("tags")) ?? []
     }
 }

--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -103,6 +103,19 @@ public extension Decoder {
         return try container.decode(type, forKey: key)
     }
 
+    /// Decode an optional value for a given key, specified as a string. Throws an error if the
+    /// specified key exists but is not able to be decoded as the inferred type.
+    func decodeIfPresent<T: Decodable>(_ key: String, as type: T.Type = T.self) throws -> T? {
+        return try decodeIfPresent(AnyCodingKey(key), as: type)
+    }
+
+    /// Decode an optional value for a given key, specified as a `CodingKey`. Throws an error if the
+    /// specified key exists but is not able to be decoded as the inferred type.
+    func decodeIfPresent<T: Decodable, K: CodingKey>(_ key: K, as type: T.Type = T.self) throws -> T? {
+        let container = try self.container(keyedBy: K.self)
+        return try container.decodeIfPresent(type, forKey: key)
+    }
+
     /// Decode a date from a string for a given key (specified as a string), using a
     /// specific formatter. To decode a date using the decoder's default settings,
     /// simply decode it like any other value instead of using this method.

--- a/Tests/CodextendedTests/CodextendedTests.swift
+++ b/Tests/CodextendedTests/CodextendedTests.swift
@@ -19,6 +19,41 @@ final class CodextendedTests: XCTestCase {
         XCTAssertEqual(valueA, valueB)
     }
 
+    func testDecodeIfPresent() throws {
+        struct Value: Decodable, Equatable {
+            let stringA: String?
+            let stringB: String?
+
+            init(from decoder: Decoder) throws {
+                stringA = try decoder.decodeIfPresent("stringA")
+                stringB = try decoder.decodeIfPresent("stringB")
+            }
+        }
+
+        let value = try Data(#"{"stringA": "stringA"}"#.utf8).decoded() as Value
+        XCTAssertEqual(value.stringA, "stringA")
+        XCTAssertNil(value.stringB)
+    }
+
+    func testDecodeIfPresentTypeMismatch() throws {
+        struct Value: Decodable, Equatable {
+            let string: String?
+
+            init(from decoder: Decoder) throws {
+                string = try decoder.decodeIfPresent("string")
+            }
+        }
+
+        do {
+            let _ = try Data(#"{"string": 123}"#.utf8).decoded() as Value
+            XCTFail("Decoding expected to fail due to type mismatch.")
+        } catch DecodingError.typeMismatch {
+            return
+        } catch {
+            XCTFail("Expected `typeMismatch` error.")
+        }
+    }
+
     func testSingleValue() throws {
         struct Value: Codable, Equatable {
             let string: String
@@ -185,6 +220,8 @@ final class CodextendedTests: XCTestCase {
 extension CodextendedTests: LinuxTestable {
     static var allTests = [
         ("testEncodingAndDecoding", testEncodingAndDecoding),
+        ("testDecodeIfPresent", testDecodeIfPresent),
+        ("testDecodeIfPresentTypeMismatch", testDecodeIfPresentTypeMismatch),
         ("testSingleValue", testSingleValue),
         ("testUsingStringAsKey", testUsingStringAsKey),
         ("testUsingCodingKey", testUsingCodingKey),


### PR DESCRIPTION
Hi John,

The key motivation for this addition was to enable propagation of errors, primarily DecodingError.typeMismatch, when attempting to decode values into optional properties. While the existing functionality for optionals, supported by the `try?` notation, is valid for many use cases, it does not allow for proper alerting when the key is present, but of an incorrect type.

I am certainly open to any feedback and very much appreciate your consideration.