### PR TITLE
Add properties to AnyDateFormatter

### DIFF
--- a/Sources/Codextended/Codextended.swift
+++ b/Sources/Codextended/Codextended.swift
@@ -147,6 +147,10 @@ public extension Decoder {
 /// Protocol acting as a common API for all types of date formatters,
 /// such as `DateFormatter` and `ISO8601DateFormatter`.
 public protocol AnyDateFormatter {
+    /// The time zone for the date
+    var timeZone: TimeZone! { get set }
+    /// The format string that represents the structure of the date
+    var dateFormat: String! { get }
     /// Format a string into a date
     func date(from string: String) -> Date?
     /// Format a date into a string
@@ -156,7 +160,11 @@ public protocol AnyDateFormatter {
 extension DateFormatter: AnyDateFormatter {}
 
 @available(iOS 10.0, macOS 10.12, tvOS 10.0, *)
-extension ISO8601DateFormatter: AnyDateFormatter {}
+extension ISO8601DateFormatter: AnyDateFormatter {
+    public var dateFormat: String! {
+        return "ISO 8601"
+    }
+}
 
 // MARK: - Private supporting types
 


### PR DESCRIPTION
### Why
Publish supports the use of a custom `DateFormatter` for decoding dates. It would be nice to allow users to also use `ISO8601DateFormatter` as the custom date formatter.

*See previous discussion on the issue here: [Publish PR #77](https://github.com/JohnSundell/Publish/pull/77).*

### Problem
`AnyDateFormatter` does not provide all the properties that Publish needs in order to use it as a replacement for `DateFormatter`.

### Solution
Add two properties to the `AnyDateFormatter` protocol to allow us to replace `DateFormatter` in Publish.

- `timeZone: TimeZone!`
- `dateFormat: String!`

`dateFormat` is readonly as Publish only needs to read this value for debugging purposes. `DateFormatter` already implements this requirement, so we only needed to provide a value for `ISO8601DateFormatter` that will be useful during debugging.

You can see how these changes would be integrated into Publish by looking at this draft PR. https://github.com/JohnSundell/Publish/pull/109